### PR TITLE
Fix read the docs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,10 @@
+# .readthedocs.yml
+
+build:
+  image: latest
+
+python:
+  version: 3.7
+  setup_py_install: true
+
+requirements_file: requirements-dev.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ build:
   image: latest
 
 python:
-  version: 3.7
+  version: 3.6
   setup_py_install: true
 
 requirements_file: requirements-dev.txt


### PR DESCRIPTION
the docs failed to build because Read the docs use Python 3.5 by default, you have to use a configuration file to specify the Python version (3.6 min here).